### PR TITLE
There's a glitch in RSCD, where you don't always pick up the item like yo

### DIFF
--- a/GameServer/src/org/moparscape/msc/gs/phandler/client/PickupItem.java
+++ b/GameServer/src/org/moparscape/msc/gs/phandler/client/PickupItem.java
@@ -70,8 +70,11 @@ public class PickupItem implements PacketHandler {
 	}
 
 	player.setStatus(Action.TAKING_GITEM);
-	Instance.getDelayedEventHandler().add(new WalkToPointEvent(player, location, 1, false) {
-	    public void arrived() {
+	Instance.getDelayedEventHandler().add(new DelayedEvent(player, 0) {
+	    public void run() {
+		if(!owner.withinRange(location, 0)) {
+			return;
+		}
 		if (owner.isBusy() || owner.isRanging() || !tile.hasItem(item) || !owner.nextTo(item) || owner.getStatus() != Action.TAKING_GITEM) {
 		    return;
 		}
@@ -142,6 +145,7 @@ public class PickupItem implements PacketHandler {
 		owner.getActionSender().sendSound("takeobject");
 		owner.getInventory().add(invItem);
 		owner.getActionSender().sendInventory();
+		super.running = false;
 	    }
 	});
     }


### PR DESCRIPTION
There's a glitch in RSCD, where you don't always pick up the item like you're supposed to, this is caused most likely by "hasMoved" check in WalkToPointEvent, it doesn't update the variable as fast as it should
So it will not pick up the item immediatly, which will annoy people a LOT, especially in drop parties and picking up loot, there should be absolutely no delay when picking up items, this fixes it, but might not be the best approach for it, This fix is also in RSCE, you can test it "live" there.
